### PR TITLE
Build x86_64 and universal2 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,6 +37,9 @@ jobs:
         fetch-depth: 0
 
     - uses: pypa/cibuildwheel@v2.8.1
+      env:
+        # Use platform specific environment variable to build x86_64 and universal2 wheels for OSX
+        CIBW_ARCHS_MACOS: x86_64 universal2
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(pylibmagic VERSION 0.2.0 DESCRIPTION "Library for compiling libmagic usi
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MACOSX_RPATH 1)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(CMAKE_C_FLAGS "-arch x86_64 -arch arm64")
+endif()
 
 set(libmagic_PREFIX libmagic)
 
@@ -14,7 +17,7 @@ ExternalProject_Add(libmagic
     GIT_TAG FILE5_41
     PREFIX ${libmagic_PREFIX}
     BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND autoreconf -f -i && ./configure --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR} --datadir=<INSTALL_DIR>/${CMAKE_INSTALL_DATADIR}
+    CONFIGURE_COMMAND autoreconf -f -i && ./configure --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR} --datadir=<INSTALL_DIR>/${CMAKE_INSTALL_DATADIR} CFLAGS=${CMAKE_C_FLAGS}
     BUILD_COMMAND ${MAKE_EXE}
     INSTALL_COMMAND ${MAKE_EXE}
 )


### PR DESCRIPTION
I've tested the universal2 wheels on a M1 notebook and they're working
fine. The size difference between universal2 wheels and arch specific
wheels are very small, but I kept the x86_64 wheels for older pip versions
(20.3 is required for universal2 wheels).

I've triggered another run from https://github.com/mvdbeek/pylibmagic/actions/runs/2831622934 if you want to test out the wheels