### PR TITLE
ci: remove old unnecessary limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      # Official actions have moving tags like v1
-      # that are used, so they don't need updates here
-      - dependency-name: "actions/*"


### PR DESCRIPTION
This is not necessary anymore, it defendant bought now correctly, keeps the same version style when updating. And it’s blocking you from getting important updates.