### PR TITLE
ci: use trusted publisher deployment

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -76,6 +76,9 @@ jobs:
     needs: [build_wheels, make_sdist, download_cirrus]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/download-artifact@v3
@@ -88,8 +91,4 @@ jobs:
           find artifacts -type f -exec mv -t dist {} +
           ls -lavh dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.6
-        with:
-          user: __token__
-          # Remember to generate this and set it in "GitHub Secrets"
-          password: ${{ secrets.pypi_password }}
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Following the Scikit-HEP Developer Guidelines. The secret should be deleted on GHA, the token deleted on PyPI, and this repo and pypi environment be set on PyPI's project page as a trusted publisher.
